### PR TITLE
NumPy 2.0 compatibility fixes

### DIFF
--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -309,7 +309,7 @@ class LIRAAttack(Attack):
 
     def _get_p_normal(self, samples: np.ndarray) -> float:
         """Test whether a set of samples is normally distributed."""
-        p_normal: float = np.NaN
+        p_normal: float = np.nan
         if np.nanvar(samples) > EPS:
             with contextlib.suppress(ValueError):
                 _, p_normal = shapiro(samples)

--- a/sacroml/attacks/target.py
+++ b/sacroml/attacks/target.py
@@ -312,8 +312,8 @@ class Target:  # pylint: disable=too-many-instance-attributes
                 test = self.model.score(self.X_test, self.y_test)
                 return test - train
             except sklearn.exceptions.NotFittedError:
-                return np.NaN
-        return np.NaN
+                return np.nan
+        return np.nan
 
     def save(self, path: str = "target", ext: str = "pkl") -> None:
         """Save the target class to persistent storage.


### PR DESCRIPTION
Closes #316 and replaces two other instances of `np.NaN` with `np.nan`. (This is already [_recommended_ for NumPy 1.x](https://numpy.org/doc/1.26/reference/constants.html#numpy.NaN) and becomes _required_ in NumPy 2.x, where several aliases like `np.NaN` have been removed to simplify the API.)

Since I was already doing this in AI-SDC/ACRO#247, I thought I might as well fix it here, too. :)