### PR TITLE
fix adaboost structural test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes:
 *   Fix Sphinx documentation not displaying attacks ([#305](https://github.com/AI-SDC/SACRO-ML/pull/305))
 *   Fix NumPy 2.0 compatibility ([#317](https://github.com/AI-SDC/SACRO-ML/pull/317))
+*   Fix AdaBoostClassifier structural test ([#318](https://github.com/AI-SDC/SACRO-ML/pull/318))
 
 ## Version 1.2.1 (Jul 29, 2024)
 

--- a/tests/attacks/test_structural_attack.py
+++ b/tests/attacks/test_structural_attack.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 from sklearn.datasets import load_breast_cancer
 from sklearn.ensemble import AdaBoostClassifier, RandomForestClassifier
@@ -200,6 +201,8 @@ def test_adaboost():
     # 'non' disclosive'
     # - base estimator =None => DecisionTreeClassifier with max_depth 1
     # also set THRESHOLD to 4
+    np.random.seed(42)
+
     param_dict = {"n_estimators": 2, "estimator": None}
     target = get_target("adaboost", **param_dict)
     myattack = sa.StructuralAttack()


### PR DESCRIPTION
Fixes #315 by setting the numpy random number seed before calling the adaboost structural test.