### PR TITLE
add save/load target train/test probas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes:
 *   Fix AdaBoostClassifier structural test ([#318](https://github.com/AI-SDC/SACRO-ML/pull/318))
 *   Fix user story examples ([#320](https://github.com/AI-SDC/SACRO-ML/pull/320), [#321](https://github.com/AI-SDC/SACRO-ML/pull/321))
 *   Update acro dependency to v0.4.8 ([#322](https://github.com/AI-SDC/SACRO-ML/pull/322))
+*   Add Target loading of probas from persistent storage ([#323](https://github.com/AI-SDC/SACRO-ML/pull/323))
 
 ## Version 1.2.1 (Jul 29, 2024)
 

--- a/sacroml/attacks/attribute_attack.py
+++ b/sacroml/attacks/attribute_attack.py
@@ -66,7 +66,7 @@ class AttributeAttack(Attack):
             Attack report.
         """
         if target.n_features < 1:
-            logger.info("Can't run attribute inference unless features are defined.")
+            logger.info("WARNING: AttributeAttack requires features to be defined.")
         else:
             logger.info("Running attribute inference attack")
             self.attack_metrics = _attribute_inference(target, self.n_cpu)

--- a/sacroml/attacks/attribute_attack.py
+++ b/sacroml/attacks/attribute_attack.py
@@ -65,15 +65,19 @@ class AttributeAttack(Attack):
         dict
             Attack report.
         """
+        if not isinstance(target.model, BaseEstimator):  # pragma: no cover
+            logger.info("WARNING: AttributeAttack only supports scikit-learn models.")
+            return {}
+
         if target.n_features < 1:
             logger.info("WARNING: AttributeAttack requires features to be defined.")
-        else:
-            logger.info("Running attribute inference attack")
-            self.attack_metrics = _attribute_inference(target, self.n_cpu)
-            output = self._make_report(target)
-            self._write_report(output)
-            return output
-        return {}
+            return {}
+
+        logger.info("Running attribute inference attack")
+        self.attack_metrics = _attribute_inference(target, self.n_cpu)
+        output = self._make_report(target)
+        self._write_report(output)
+        return output
 
     def _get_attack_metrics_instances(self) -> dict:
         """Construct the instances metric calculated, during attacks."""

--- a/sacroml/attacks/attribute_attack.py
+++ b/sacroml/attacks/attribute_attack.py
@@ -65,11 +65,11 @@ class AttributeAttack(Attack):
         dict
             Attack report.
         """
-        if not isinstance(target.model, BaseEstimator):  # pragma: no cover
-            logger.info("WARNING: AttributeAttack only supports scikit-learn models.")
+        if target.model is None or not target.has_data():  # pragma: no cover
+            logger.info("WARNING: AttributeAttack requires a loadable model.")
             return {}
 
-        if target.n_features < 1:
+        if target.n_features < 1 or not target.has_raw_data():  # pragma: no cover
             logger.info("WARNING: AttributeAttack requires features to be defined.")
             return {}
 

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -93,7 +93,7 @@ class LIRAAttack(Attack):
             Attack report.
         """
         # check it can be run
-        if not isinstance(target.model, sklearn.base.BaseEstimator):
+        if not isinstance(target.model, sklearn.base.BaseEstimator):  # pragma: no cover
             logger.info("WARNING: LiRA only supports scikit-learn models.")
             return {}
         # prepare

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -92,6 +92,10 @@ class LIRAAttack(Attack):
         dict
             Attack report.
         """
+        # check it can be run
+        if not isinstance(target.model, sklearn.base.BaseEstimator):
+            logger.info("WARNING: LiRA only supports scikit-learn models.")
+            return {}
         # prepare
         shadow_clf = sklearn.base.clone(target.model)
         target = self._check_and_update_dataset(target)

--- a/sacroml/attacks/likelihood_attack.py
+++ b/sacroml/attacks/likelihood_attack.py
@@ -93,8 +93,8 @@ class LIRAAttack(Attack):
             Attack report.
         """
         # check it can be run
-        if not isinstance(target.model, sklearn.base.BaseEstimator):  # pragma: no cover
-            logger.info("WARNING: LiRA only supports scikit-learn models.")
+        if target.model is None or not target.has_data():  # pragma: no cover
+            logger.info("WARNING: LiRA requires a loadable model.")
             return {}
         # prepare
         shadow_clf = sklearn.base.clone(target.model)

--- a/sacroml/attacks/structural_attack.py
+++ b/sacroml/attacks/structural_attack.py
@@ -292,8 +292,8 @@ class StructuralAttack(Attack):
         """
         self.target = target
         # check it can be run
-        if not isinstance(target.model, BaseEstimator):
-            logger.info("WARNING: StructuralAttack only supports scikit-learn models.")
+        if target.model is None or not target.has_data():  # pragma: no cover
+            logger.info("WARNING: StructuralAttack requires a loadable model.")
             return {}
 
         # get proba values for training data

--- a/sacroml/attacks/structural_attack.py
+++ b/sacroml/attacks/structural_attack.py
@@ -291,12 +291,10 @@ class StructuralAttack(Attack):
             Attack report.
         """
         self.target = target
-        if target.model is None:
-            errstr = (
-                "cannot currently call StructuralAttack.attack() "
-                "unless the target contains a trained model"
-            )
-            raise NotImplementedError(errstr)
+        # check it can be run
+        if not isinstance(target.model, BaseEstimator):
+            logger.info("WARNING: StructuralAttack only supports scikit-learn models.")
+            return {}
 
         # get proba values for training data
         x = self.target.X_train

--- a/sacroml/attacks/target.py
+++ b/sacroml/attacks/target.py
@@ -270,6 +270,8 @@ class Target:  # pylint: disable=too-many-instance-attributes
         self._save_numpy(path, target, "y_train_orig")
         self._save_numpy(path, target, "X_test_orig")
         self._save_numpy(path, target, "y_test_orig")
+        self._save_numpy(path, target, "proba_train")
+        self._save_numpy(path, target, "proba_test")
 
     def _load_data(self, path: str, target: dict) -> None:
         """Load the target model data.
@@ -291,6 +293,8 @@ class Target:  # pylint: disable=too-many-instance-attributes
         self._load_array(path, target, "y_train_orig")
         self._load_array(path, target, "X_test_orig")
         self._load_array(path, target, "y_test_orig")
+        self._load_array(path, target, "proba_train")
+        self._load_array(path, target, "proba_test")
 
     def _ge(self) -> float:
         """Return the model generalisation error.

--- a/sacroml/attacks/target.py
+++ b/sacroml/attacks/target.py
@@ -405,6 +405,30 @@ class Target:  # pylint: disable=too-many-instance-attributes
         """
         self.safemodel = data
 
+    def has_data(self) -> bool:
+        """Return whether the target has all processed data."""
+        return (
+            self.X_train is not None
+            and self.y_train is not None
+            and self.X_test is not None
+            and self.y_test is not None
+        )
+
+    def has_raw_data(self) -> bool:
+        """Return whether the target has all raw data."""
+        return (
+            self.X_orig is not None
+            and self.y_orig is not None
+            and self.X_train_orig is not None
+            and self.y_train_orig is not None
+            and self.X_test_orig is not None
+            and self.y_test_orig is not None
+        )
+
+    def has_probas(self) -> bool:
+        """Return whether the target has all probability data."""
+        return self.proba_train is not None and self.proba_test is not None
+
     def __str__(self) -> str:
         """Return the name of the dataset used."""
         return self.dataset_name

--- a/sacroml/attacks/target.py
+++ b/sacroml/attacks/target.py
@@ -410,7 +410,7 @@ class Target:  # pylint: disable=too-many-instance-attributes
         return self.dataset_name
 
 
-def get_array_pkl(path: str, name: str):
+def get_array_pkl(path: str, name: str):  # pragma: no cover
     """Load a data array from pickle."""
     try:
         with open(path, "rb") as fp:
@@ -426,7 +426,7 @@ def get_array_pkl(path: str, name: str):
     return arr
 
 
-def get_array_csv(path: str, name: str):
+def get_array_csv(path: str, name: str):  # pragma: no cover
     """Load a data array from csv."""
     try:
         arr = pd.read_csv(path, header=None).values

--- a/sacroml/attacks/target.py
+++ b/sacroml/attacks/target.py
@@ -230,9 +230,9 @@ class Target:  # pylint: disable=too-many-instance-attributes
         _, ext = os.path.splitext(path)
         if ext == ".pkl":
             arr = get_array_pkl(path, name)
-        elif ext == ".csv":
+        elif ext == ".csv":  # pragma: no cover
             arr = get_array_csv(path, name)
-        else:
+        else:  # pragma: no cover
             raise ValueError(f"Target cannot load {ext} files.") from None
         setattr(self, name, arr)
 

--- a/sacroml/attacks/worst_case_attack.py
+++ b/sacroml/attacks/worst_case_attack.py
@@ -114,18 +114,14 @@ class WorstCaseAttack(Attack):  # pylint: disable=too-many-instance-attributes
         train_c = None
         test_c = None
         # compute target model probas if possible
-        if (
-            target.model is not None
-            and target.X_train is not None
-            and target.y_train is not None
-        ):
+        if target.model is not None and target.has_data():
             proba_train = target.model.predict_proba(target.X_train)
             proba_test = target.model.predict_proba(target.X_test)
             if self.include_model_correct_feature:
                 train_c = 1 * (target.y_train == target.model.predict(target.X_train))
                 test_c = 1 * (target.y_test == target.model.predict(target.X_test))
         # use supplied target model probas if unable to compute
-        elif target.proba_train is not None and target.proba_test is not None:
+        elif target.has_probas():
             proba_train = target.proba_train
             proba_test = target.proba_test
         # cannot proceed

--- a/sacroml/attacks/worst_case_attack.py
+++ b/sacroml/attacks/worst_case_attack.py
@@ -130,7 +130,7 @@ class WorstCaseAttack(Attack):  # pylint: disable=too-many-instance-attributes
             proba_test = target.proba_test
         # cannot proceed
         else:
-            logger.info("Insufficient Target details to run worst case attack.")
+            logger.info("WARNING: WorstCaseAttack requires more Target details.")
             return {}
         # execute attack
         self.attack_from_preds(

--- a/sacroml/preprocessing/loaders.py
+++ b/sacroml/preprocessing/loaders.py
@@ -1,6 +1,6 @@
 """Handlers to pull in datasets and perform preprocessing."""
 
-# pylint: disable=consider-using-with, too-many-return-statements
+# pylint: disable=too-many-return-statements
 
 import logging
 import os

--- a/tests/attacks/test_structural_attack.py
+++ b/tests/attacks/test_structural_attack.py
@@ -158,7 +158,7 @@ def test_non_trees():
     # remove model
     target.model = None
     myattack2 = sa.StructuralAttack()
-    assert myattack2.attack(target) == {}
+    assert not myattack2.attack(target)
 
 
 def test_dt():

--- a/tests/attacks/test_structural_attack.py
+++ b/tests/attacks/test_structural_attack.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 from sklearn.datasets import load_breast_cancer
 from sklearn.ensemble import AdaBoostClassifier, RandomForestClassifier
 from sklearn.model_selection import train_test_split
@@ -159,8 +158,7 @@ def test_non_trees():
     # remove model
     target.model = None
     myattack2 = sa.StructuralAttack()
-    with pytest.raises(NotImplementedError):
-        myattack2.attack(target)
+    assert myattack2.attack(target) == {}
 
 
 def test_dt():


### PR DESCRIPTION
Partly addresses #294 

* Adds saving/loading Target model training and testing probability arrays to help support user story 4 from the CLI.
* Adds Target object loading csv files as well as pkl
* Adds additional checks that attacks can be run and skips them (with a logger warning) instead of raising exceptions

Supports user story 4 where `sacroml gen-target` is run and any model is provided along with csv files (csv files should not have headers) for probas and processed data (X_train, etc.), Subsequently `sacroml gen-attack` with defaults and then running `sacroml run target/ attack.yaml` In this scenario only the worst case attack can run because the others require a loaded model. Note it also wont yet copy the model to the target directory unless it's a scikit-learn model. 

