### PR TITLE
add attribute inference documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Development
+
+Changes:
+*   Improve attribute inference attack documentation ([#340](https://github.com/AI-SDC/SACRO-ML/pull/340))
+
 ## Version 1.3.0 (Jun 17, 2025)
 
 Changes:

--- a/docs/source/attacks/attribute.rst
+++ b/docs/source/attacks/attribute.rst
@@ -9,7 +9,7 @@ The attack computes an upper bound on the fraction of records that are vulnerabl
 Usage
 -----
 
-To run the attribute attack, the feature encoding and the original unprocessed data must be included within the :py:class:`sacroml.attacks.target.Target` that is passed to the attribute attack object.
+To run the attribute attack, in addition to the usual processed data splits, the feature encoding and the original unprocessed data must be included within the :py:class:`sacroml.attacks.target.Target` that is passed to the attribute attack object.
 
 See the examples:
 

--- a/docs/source/attacks/attribute.rst
+++ b/docs/source/attacks/attribute.rst
@@ -1,5 +1,30 @@
 Attribute Attack
 ================
 
+The attribute inference attack assumes that the attacker has access to a record missing the value for one attribute, and measuring whether the trained model allows more (and more accurate) predicted completions for the training set than it does for the test set. An exhaustive search of the target model's predictive confidence is performed for all possible values that complete the record (discretised for continuous attributes). The attack model then makes a prediction if one missing value (categorical) or a single unbroken range of values (continuous) leads to the highest target confidence, which is above a user-defined threshold; otherwise it reports *don't know*.
+
+The attack computes an upper bound on the fraction of records that are vulnerable, i.e., where the attack makes a correct prediction, and reports the Attribute Risk Ratio, ARR(*a*): the ratio of training and test set proportions for each attribute *a*. The attack is considered accurate if the target model's predicted label :math:`l^*` for the record with a single missing value is the same as for the actual record value :math:`l` (categorical) or the range of values yielding the same target confidence lies within :math:`l\pm10\%` (continuous). This latter condition mirrors the protection limits commonly used in cell suppression algorithms; see, for example, :cite:t:`Smith:2012`. The ARR metric recognises that any useful trained model contains some generalisable information and so only considers the model to be leaking privacy if ARR(*a*)>1. It also recognises that not all attributes will be considered equally disclosive, and so enables a discussion between TRE staff and researchers.
+
+-----
+Usage
+-----
+
+To run the attribute attack, the feature encoding and the original unprocessed data must be included within the :py:class:`sacroml.attacks.target.Target` that is passed to the attribute attack object.
+
+See the examples:
+
+* `Training <https://www.github.com/ai-sdc/sacro-ml/tree/main/examples/train_rf_nursery.py>`_ a model and including all required information.
+* `Running <https://www.github.com/ai-sdc/sacro-ml/tree/main/examples/attack_attribute.py>`_ an attribute inference attack programmatically.
+
+----------
+References
+----------
+
+.. bibliography::
+
+-------------
+API Reference
+-------------
+
 .. automodule:: sacroml.attacks.attribute_attack
     :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(1, os.path.abspath("../../attacks/"))
 project = "SACRO-ML"
 copyright = "2025, GRAIMATTER and SACRO Project Team"
 author = "GRAIMATTER and SACRO Project Team"
-release = "1.2.2"
+release = "1.3.0"
 
 # -- General configuration ---------------------------------------------------
 
@@ -24,10 +24,12 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.imgconverter",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx_autopackagesummary",
     "sphinx_issues",
     "sphinx_rtd_theme",
+    "sphinxcontrib.bibtex",
 ]
 
 exclude_patterns = []
@@ -36,7 +38,11 @@ exclude_patterns = []
 
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {"navigation_depth": 2}
-html_static_path = ["_static"]
+
+# -- References --------------------------------------------------------------
+
+bibtex_bibfiles = ["references.bib"]
+bibtex_default_style = "unsrt"
 
 # -- -------------------------------------------------------------------------
 

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -1,0 +1,11 @@
+@article{Smith:2012,
+    title = {A Genetic Approach to Statistical Disclosure Control},
+    author = {Smith, J. E. and Clark, A. R. and Staggemeier, A. T. and Serpell, M. C.},
+    journal = {IEEE Transactions on Evolutionary Computation},
+    volume = 3,
+    number = 16,
+    month = jun,
+    pages = {431--441},
+    year = 2012,
+    doi = {10.1109/TEVC.2011.2159271},
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ doc = [
     "sphinx-prompt",
     "sphinx-rtd-theme",
     "sphinx",
+    "sphinxcontrib-bibtex",
 ]
 test = [
     "pytest",


### PR DESCRIPTION
Improve the AIA documentation by adding a description and link to the examples.