### PR TITLE
remove redundant `X_orig` and `y_orig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes:
 *   Improve attribute inference attack documentation ([#340](https://github.com/AI-SDC/SACRO-ML/pull/340))
 *   Refactor `Target` class - standardise use of constructor to wrap data ([#342](https://github.com/AI-SDC/SACRO-ML/pull/342))
 *   Add LiRA support for multidimensional vectors such as images with multiple channels ([#343](https://github.com/AI-SDC/SACRO-ML/pull/343))
+*   Remove redundant `X_orig` and `y_orig` from `Target` class ([#344](https://github.com/AI-SDC/SACRO-ML/pull/344))
 
 ## Version 1.3.0 (Jun 17, 2025)
 

--- a/examples/pytorch/train_pytorch.py
+++ b/examples/pytorch/train_pytorch.py
@@ -69,8 +69,6 @@ if __name__ == "__main__":
         y_test=y_test,
         # original unprocessed data (for attribute attack)
         # in this example we just use the processed data since it's all floats
-        X_orig=X,
-        y_orig=y,
         X_train_orig=X_train,
         y_train_orig=y_train,
         X_test_orig=X_test,

--- a/examples/safemodel.py
+++ b/examples/safemodel.py
@@ -64,8 +64,6 @@ if __name__ == "__main__":
         y_train=y_train,
         X_test=X_test,
         y_test=y_test,
-        X_orig=X,
-        y_orig=y,
         X_train_orig=X_train_orig,
         y_train_orig=y_train_orig,
         X_test_orig=X_test_orig,

--- a/examples/train_rf_nursery.py
+++ b/examples/train_rf_nursery.py
@@ -51,8 +51,6 @@ if __name__ == "__main__":
         X_test=X_test,
         y_test=y_test,
         # original unprocessed data
-        X_orig=X,
-        y_orig=y,
         X_train_orig=X_train_orig,
         y_train_orig=y_train_orig,
         X_test_orig=X_test_orig,

--- a/examples/user_stories/user_story_1/user_story_1_researcher_template.py
+++ b/examples/user_stories/user_story_1/user_story_1_researcher_template.py
@@ -109,8 +109,6 @@ def main():
         X_test=X_test,
         y_test=y_test,
         # original unprocessed data
-        X_orig=data,
-        y_orig=labels,
         X_train_orig=X_train_orig,
         y_train_orig=y_train_orig,
         X_test_orig=X_test_orig,

--- a/examples/user_stories/user_story_7/user_story_7_researcher_template.py
+++ b/examples/user_stories/user_story_7/user_story_7_researcher_template.py
@@ -102,8 +102,6 @@ def run_user_story():
         y_train=y_train,
         X_test=X_test,
         y_test=y_test,
-        X_orig=data,
-        y_orig=labels,
         X_train_orig=X_train_orig,
         y_train_orig=y_train_orig,
         X_test_orig=X_test_orig,

--- a/sacroml/attacks/attribute_attack.py
+++ b/sacroml/attacks/attribute_attack.py
@@ -167,13 +167,23 @@ def _unique_max(confidences: list[float], threshold: float) -> bool:
     return False
 
 
+def _get_unique_features(
+    X_train: np.ndarray, X_test: np.ndarray, feature_id: int
+) -> np.ndarray:
+    """Return unique values of a given feature."""
+    feature_train = X_train[:, feature_id]
+    feature_test = X_test[:, feature_id]
+    combined_feature = np.concatenate((feature_train, feature_test))
+    return np.unique(combined_feature)
+
+
 def _get_inference_data(  # pylint: disable=too-many-locals
     target: Target, feature_id: int, memberset: bool
 ) -> tuple[np.ndarray, np.ndarray, float]:
     """Return a dataset of each sample with the attributes to test."""
     attack_feature: dict = target.features[feature_id]
     indices: list[int] = attack_feature["indices"]
-    unique = np.unique(target.X_orig[:, feature_id])
+    unique = _get_unique_features(target.X_train_orig, target.X_test_orig, feature_id)
     n_unique: int = len(unique)
     values = unique
     if attack_feature["encoding"] == "onehot":

--- a/sacroml/attacks/target.py
+++ b/sacroml/attacks/target.py
@@ -28,8 +28,6 @@ DATA_ATTRIBUTES: list[str] = [
     "y_train",
     "X_test",
     "y_test",
-    "X_orig",
-    "y_orig",
     "X_train_orig",
     "y_train_orig",
     "X_test_orig",
@@ -76,10 +74,6 @@ class Target:  # pylint: disable=too-many-instance-attributes
         The (processed) testing inputs.
     y_test : np.ndarray or None
         The (processed) testing outputs.
-    X_orig : np.ndarray or None
-        The original (unprocessed) dataset inputs.
-    y_orig : np.ndarray or None
-        The original (unprocessed) dataset outputs.
     X_train_orig : np.ndarray or None
         The original (unprocessed) training inputs.
     y_train_orig : np.ndarray or None
@@ -115,8 +109,6 @@ class Target:  # pylint: disable=too-many-instance-attributes
     y_train: np.ndarray | None = None
     X_test: np.ndarray | None = None
     y_test: np.ndarray | None = None
-    X_orig: np.ndarray | None = None
-    y_orig: np.ndarray | None = None
     X_train_orig: np.ndarray | None = None
     y_train_orig: np.ndarray | None = None
     X_test_orig: np.ndarray | None = None
@@ -190,8 +182,6 @@ class Target:  # pylint: disable=too-many-instance-attributes
     def has_raw_data(self) -> bool:
         """Return whether the target has all raw data."""
         attrs: list[str] = [
-            "X_orig",
-            "y_orig",
             "X_train_orig",
             "y_train_orig",
             "X_test_orig",

--- a/sacroml/config/target.py
+++ b/sacroml/config/target.py
@@ -19,7 +19,7 @@ from sacroml.config import utils
 from sacroml.version import __version__
 
 arrays_pro = ["X_train", "y_train", "X_test", "y_test"]
-arrays_raw = ["X", "y", "X_train_orig", "y_train_orig", "X_test_orig", "y_test_orig"]
+arrays_raw = ["X_train_orig", "y_train_orig", "X_test_orig", "y_test_orig"]
 arrays_proba = ["proba_train", "proba_test"]
 encodings = ["onehot", "str", "int", "float"]
 

--- a/tests/attacks/test_attacks_target.py
+++ b/tests/attacks/test_attacks_target.py
@@ -32,8 +32,6 @@ def test_target(get_target):
     assert np.array_equal(tre_target.y_train, target.y_train)
     assert np.array_equal(tre_target.X_test, target.X_test)
     assert np.array_equal(tre_target.y_test, target.y_test)
-    assert np.array_equal(tre_target.X_orig, target.X_orig)
-    assert np.array_equal(tre_target.y_orig, target.y_orig)
     assert np.array_equal(tre_target.X_train_orig, target.X_train_orig)
     assert np.array_equal(tre_target.y_train_orig, target.y_train_orig)
     assert np.array_equal(tre_target.X_test_orig, target.X_test_orig)

--- a/tests/attacks/test_pytorch.py
+++ b/tests/attacks/test_pytorch.py
@@ -89,8 +89,6 @@ def test_pytorch() -> None:  # pylint:disable=too-many-locals
         X_test=X_test,
         y_test=y_test,
         # original unprocessed data
-        X_orig=X_orig,
-        y_orig=y_orig,
         X_train_orig=X_train,
         y_train_orig=y_train,
         X_test_orig=X_test,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,7 +157,6 @@ def get_target(request) -> Target:  # pylint: disable=too-many-locals
     X_train_orig = np.hstack((X_train_orig, dummy_tr))
     X_test = np.hstack((X_test, dummy_te))
     X_test_orig = np.hstack((X_test_orig, dummy_te))
-    xmore = np.concatenate((X_train_orig, X_test_orig))
     n_features = np.shape(X_train_orig)[1]
 
     # fit model
@@ -171,8 +170,6 @@ def get_target(request) -> Target:  # pylint: disable=too-many-locals
         y_train=y_train,
         X_test=X_test,
         y_test=y_test,
-        X_orig=xmore,
-        y_orig=y,
         X_train_orig=X_train_orig,
         y_train_orig=y_train_orig,
         X_test_orig=X_test_orig,
@@ -220,8 +217,6 @@ def get_target_multiclass() -> Target:
         y_train=y_train,
         X_test=X_test,
         y_test=y_test,
-        X_orig=X,
-        y_orig=y,
         X_train_orig=X_train,
         y_train_orig=y_train,
         X_test_orig=X_test,


### PR DESCRIPTION
Remove redundant `X_orig` and `y_orig` from the `Target` class - the raw train and test arrays are already passed and can be concatenated as necessary.