### PR TITLE
fix: replace NaN and Infinity with null in JSON reports

### DIFF
--- a/sacroml/attacks/report.py
+++ b/sacroml/attacks/report.py
@@ -126,6 +126,9 @@ def write_json(output: dict, dest: str) -> None:
     """Write attack report to JSON."""
     attack_formatter = GenerateJSONModule(dest + ".json")
     attack_report: str = json.dumps(output, cls=CustomJSONEncoder)
+    attack_report = attack_report.replace("-Infinity", "null")
+    attack_report = attack_report.replace("Infinity", "null")
+    attack_report = attack_report.replace("NaN", "null")
     attack_name: str = output["metadata"]["attack_name"]
     attack_formatter.add_attack_output(attack_report, attack_name)
 

--- a/sacroml/attacks/report.py
+++ b/sacroml/attacks/report.py
@@ -122,13 +122,32 @@ STRUCTURAL_GLOSSARY = {
 }
 
 
+def _sanitise_floats(obj: Any) -> Any:
+    """Recursively replace non-finite floats with None.
+
+    Parameters
+    ----------
+    obj : Any
+        Object to sanitise.
+
+    Returns
+    -------
+    Any
+        Sanitised object with non-finite floats replaced by None.
+    """
+    if isinstance(obj, float) and (np.isnan(obj) or np.isinf(obj)):
+        return None
+    if isinstance(obj, dict):
+        return {k: _sanitise_floats(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitise_floats(v) for v in obj]
+    return obj
+
+
 def write_json(output: dict, dest: str) -> None:
     """Write attack report to JSON."""
     attack_formatter = GenerateJSONModule(dest + ".json")
-    attack_report: str = json.dumps(output, cls=CustomJSONEncoder)
-    attack_report = attack_report.replace("-Infinity", "null")
-    attack_report = attack_report.replace("Infinity", "null")
-    attack_report = attack_report.replace("NaN", "null")
+    attack_report: str = json.dumps(_sanitise_floats(output), cls=CustomJSONEncoder)
     attack_name: str = output["metadata"]["attack_name"]
     attack_formatter.add_attack_output(attack_report, attack_name)
 

--- a/sacroml/attacks/report.py
+++ b/sacroml/attacks/report.py
@@ -137,6 +137,8 @@ def _sanitise_floats(obj: Any) -> Any:
     """
     if isinstance(obj, float) and (np.isnan(obj) or np.isinf(obj)):
         return None
+    if isinstance(obj, np.ndarray):
+        return _sanitise_floats(obj.tolist())
     if isinstance(obj, dict):
         return {k: _sanitise_floats(v) for k, v in obj.items()}
     if isinstance(obj, list):

--- a/tests/attacks/test_report.py
+++ b/tests/attacks/test_report.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import json
+import os
+import tempfile
+
 import numpy as np
+import pytest
 from fpdf import FPDF
 
 from sacroml.attacks import report
@@ -42,3 +47,40 @@ def test_dict():
     mydict = {"a": "hello", "b": "world"}
     report._write_dict(pdf, mydict, border=BORDER)
     pdf.close()
+
+
+def test_write_json_sanitises_non_finite_floats():
+    """Test write_json replaces nan/inf values with null in JSON output.
+
+    Parameters
+    ----------
+    None
+
+    Notes
+    -----
+    Ensures that float('nan'), float('inf'), and float('-inf') are serialised
+    as JSON null rather than the bare NaN/Infinity tokens that violate the
+    JSON specification.
+    """
+    metrics = {
+        "a_nan": float("nan"),
+        "b_inf": float("inf"),
+        "c_neginf": float("-inf"),
+        "d_normal": 1.5,
+    }
+    output = {
+        "metadata": {"attack_name": "test_attack"},
+        "metrics": metrics,
+    }
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dest = os.path.join(tmpdir, "report")
+        report.write_json(output, dest)
+        path = dest + ".json"
+        with open(path, encoding="utf-8") as fp:
+            data = json.load(fp)
+
+    inner = data["test_attack"]["metrics"]
+    assert inner["a_nan"] is None
+    assert inner["b_inf"] is None
+    assert inner["c_neginf"] is None
+    assert inner["d_normal"] == pytest.approx(1.5)

--- a/tests/attacks/test_report.py
+++ b/tests/attacks/test_report.py
@@ -67,6 +67,7 @@ def test_write_json_sanitises_non_finite_floats():
         "b_inf": float("inf"),
         "c_neginf": float("-inf"),
         "d_normal": 1.5,
+        "BaNaNa": "BaNaNa",
     }
     output = {
         "metadata": {"attack_name": "test_attack"},
@@ -84,3 +85,4 @@ def test_write_json_sanitises_non_finite_floats():
     assert inner["b_inf"] is None
     assert inner["c_neginf"] is None
     assert inner["d_normal"] == pytest.approx(1.5)
+    assert inner["BaNaNa"] == "BaNaNa"

--- a/tests/attacks/test_report.py
+++ b/tests/attacks/test_report.py
@@ -68,6 +68,7 @@ def test_write_json_sanitises_non_finite_floats():
         "c_neginf": float("-inf"),
         "d_normal": 1.5,
         "BaNaNa": "BaNaNa",
+        "array": np.array([1.0, np.nan, np.inf]),
     }
     output = {
         "metadata": {"attack_name": "test_attack"},
@@ -86,3 +87,4 @@ def test_write_json_sanitises_non_finite_floats():
     assert inner["c_neginf"] is None
     assert inner["d_normal"] == pytest.approx(1.5)
     assert inner["BaNaNa"] == "BaNaNa"
+    assert inner["array"] == [1.0, None, None]


### PR DESCRIPTION
Closes #366

JSON reports produced by attacks could contain bare `NaN`, `Infinity`, 
and `-Infinity` tokens which are invalid per the JSON spec and cause 
parse errors in browsers.

Changes:
- Added float nan/inf guard in `CustomJSONEncoder.default()`
- Sanitised output string in `write_json()` via `.replace()`
- Added test to verify non-finite floats serialise as `null`