### PR TITLE
fix: prevent data arrays being serialized on save when dataset module is provided

### DIFF
--- a/sacroml/attacks/target.py
+++ b/sacroml/attacks/target.py
@@ -390,6 +390,13 @@ class Target:
 
     def _save_array(self, path: str, target: dict, attr_name: str) -> None:
         """Save numpy array as pickle."""
+        # When a dataset module is provided the data arrays are re-populated
+        # from it on every load(); serialising them would defeat the purpose
+        # of using a module and cause a re-save to write the full dataset to
+        # disk
+        if self.dataset_module_path and attr_name in ARRAYS:
+            target[f"{attr_name}_path"] = ""
+            return
         arr = getattr(self, attr_name)
         if arr is not None:
             arr_path = os.path.join(path, f"{attr_name}.pkl")

--- a/tests/attacks/test_attacks_target.py
+++ b/tests/attacks/test_attacks_target.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import numpy as np
 import pytest
 from sklearn.ensemble import RandomForestClassifier
@@ -50,3 +52,55 @@ def test_target(get_target):
         y_test_orig=target.y_test_orig,
     )
     assert new_target
+
+
+def test_save_skips_data_arrays_when_dataset_module_set(tmp_path):
+    """Test data arrays are not serialised when a dataset module path is set.
+
+    After a round-trip load() followed by
+    save(), data array pkl files must not be written when a dataset module
+    is provided.
+    """
+    module_path = tmp_path / "mock_dataset.py"
+    module_path.write_text(
+        "import numpy as np\n"
+        "from sacroml.attacks.data import SklearnDataHandler\n\n\n"
+        "class MockDataset(SklearnDataHandler):\n"
+        "    def __init__(self):\n"
+        "        pass\n\n"
+        "    def __len__(self):\n"
+        "        return 10\n\n"
+        "    def get_data(self):\n"
+        "        return np.zeros((10, 2)), np.zeros(10)\n\n"
+        "    def get_raw_data(self):\n"
+        "        return None\n\n"
+        "    def get_subset(self, X, y, indices):\n"
+        "        idx = list(indices)\n"
+        "        return X[idx], y[idx]\n",
+        encoding="utf-8",
+    )
+
+    X_train = np.zeros((6, 2))
+    y_train = np.zeros(6)
+    X_test = np.zeros((4, 2))
+    y_test = np.zeros(4)
+    model = RandomForestClassifier(n_estimators=1, random_state=0)
+    model.fit(X_train, y_train)
+
+    # Simulate the state after load() calls load_sklearn_dataset():
+    # dataset_module_path is set AND data arrays are populated in memory.
+    save_dir = str(tmp_path / "target_dataset_module")
+    target = Target(
+        model=model,
+        dataset_module_path=str(module_path),
+        dataset_name="MockDataset",
+        X_train=X_train,
+        y_train=y_train,
+        X_test=X_test,
+        y_test=y_test,
+    )
+
+    target.save(save_dir)
+
+    for arr_name in ["X_train", "y_train", "X_test", "y_test"]:
+        assert not os.path.exists(os.path.join(save_dir, f"{arr_name}.pkl"))


### PR DESCRIPTION
Fixes #411 (Part B)


When a `Target` is loaded from storage with a `dataset_module_path` set, `load()` calls `load_sklearn_dataset()` or `load_pytorch_dataset()` which populates `X_train`, `y_train`, `X_test`, `y_test` in memory. A subsequent call to `save()` then finds those arrays non-null and serializes them as `.pkl` files via `_save_array()` - defeating the purpose of using a dataset module.

## Fix
Added a guard in `_save_array()` that skips serialization of dataset-backed arrays (those defined in the `ARRAYS` constant) when `dataset_module_path` is set. Non-dataset attributes (`proba_train`, `proba_test`, `indices_train`, `indices_test`) are unaffected.

## Changes
- `sacroml/attacks/target.py` - guard added to `_save_array()`
- `tests/attacks/test_attacks_target.py` - regression test added

## Notes
Part A of #411 (PyTorch in-RAM numpy conversion) is a larger architectural refactor and is out of scope for this PR.

I believe to solve the former part of this issue it would need a redesign to  the internal data contract so attacks can accept DataLoaders (or lazy tensors) in addition to numpy arrays. I believe this would require refactoring ~100 lines of code in attacks/ , utils.py

@rpreen 