### PR TITLE
test: clean up test warnings and resolve matplotlib backend issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          pytest --cov=./ --cov-report=xml
+          pytest --cov=sacroml --cov=tests --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -59,6 +59,10 @@ authors:
   - family-names: Ikechukwu
     given-names: Jessica
     affiliation: University of the West of England
+  - family-names: Ahmad
+    given-names: Hasaan
+    affiliation: University of the West of England
+    orcid: https://orcid.org/0009-0009-2443-3015
 identifiers:
   - type: doi
     value: 10.5281/zenodo.7080279

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,8 +167,10 @@ docstring-code-line-length = 80
 [tool.ruff.lint.extend-per-file-ignores]
 "user_stories/**/*" = ["ANN"]
 "tests/**/*" = ["S101", "PLR2004", "ANN"]
+"tests/conftest.py" = ["ARG001"]
 "sacroml/attacks/structural_attack.py" = ["PLR2004"]
 "sacroml/safemodel/classifiers/new_model_template.py" = ["C901"]
+
 
 [tool.codespell]
 ignore-words-list = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,3 +182,8 @@ ignore-words-list = [
     "WorstCase",
     "worst-case",
 ]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:This process.*use of fork:DeprecationWarning:multiprocess",
+]

--- a/sacroml/attacks/attribute_attack.py
+++ b/sacroml/attacks/attribute_attack.py
@@ -371,6 +371,7 @@ def plot_categorical_risk(res: dict, path: str = "") -> None:
     plt.tight_layout()
     filename = os.path.join(path, "cat_risk.png")
     fig.savefig(filename, pad_inches=0, bbox_inches="tight")
+    plt.close(fig)
     logger.debug("Saved categorical risk plot: %s", filename)
 
 
@@ -416,6 +417,7 @@ def plot_categorical_fraction(res: dict, path: str = "") -> None:
     plt.tight_layout()
     filename = os.path.join(path, "cat_frac.png")
     fig.savefig(filename, pad_inches=0, bbox_inches="tight")
+    plt.close(fig)
     logger.debug("Saved categorical fraction plot: %s", filename)
 
 

--- a/sacroml/attacks/report.py
+++ b/sacroml/attacks/report.py
@@ -214,6 +214,7 @@ def _roc_plot_single(metrics: dict, save_name: str) -> None:
     plt.xlabel("False Positive Rate")
     plt.tight_layout()
     plt.savefig(save_name)
+    plt.close()
 
 
 def _roc_plot(metrics: dict, save_name: str) -> None:
@@ -241,6 +242,7 @@ def _roc_plot(metrics: dict, save_name: str) -> None:
     plt.tight_layout()
     plt.grid()
     plt.savefig(save_name)
+    plt.close()
 
 
 def create_mia_report(attack_output: dict) -> FPDF:

--- a/sacroml/attacks/utils.py
+++ b/sacroml/attacks/utils.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import os
 import pickle
+import warnings
 from typing import Any
 
 import numpy as np
@@ -162,8 +163,9 @@ def get_n_shadow_models(shadow_path: str) -> int:
 def get_p_normal(samples: np.ndarray) -> float:
     """Test whether a set of samples is normally distributed."""
     p_normal: float = np.nan
-    if np.nanvar(samples) > EPS:
-        with contextlib.suppress(ValueError):
+    if len(samples) >= 8 and np.nanvar(samples) > EPS:
+        with contextlib.suppress(ValueError), warnings.catch_warnings():
+            warnings.simplefilter("ignore")
             _, p_normal = shapiro(samples)
     return p_normal
 

--- a/tests/attacks/test_sklearn.py
+++ b/tests/attacks/test_sklearn.py
@@ -103,7 +103,7 @@ def test_sklearn() -> None:
     records = np.array(["a", "b", "c", "a", "c", "b"]).reshape(-1, 1)
     indices = np.array([0, 1, 2, 0, 2, 1])
 
-    le = LabelEncoder().fit_transform(records)
+    le = LabelEncoder().fit_transform(records.ravel())
     assert (target.model.get_label_indices(le) == indices).all()
 
     oh = OneHotEncoder().fit_transform(records)

--- a/tests/attacks/test_structural_attack.py
+++ b/tests/attacks/test_structural_attack.py
@@ -403,6 +403,7 @@ def test_xgb_unnecessary():
     )
 
 
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 def test_sklearnmlp_nondisclosive():
     """Test for safe sklearn MLPClassifier."""
     # non-disclosive
@@ -433,6 +434,7 @@ def test_sklearnmlp_nondisclosive():
     )
 
 
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 def test_sklearnmlp_disclosive():
     """Test for safe sklearn MLPClassifier."""
     # highly disclosive

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,8 @@
-"""Common utility functions for testing."""
+"""Pytest configuration for the test suite."""
+
+import matplotlib as mpl
+
+mpl.use("Agg")
 
 import contextlib
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,14 @@ from sacroml.attacks.target import Target
 
 np.random.seed(1)
 
+
+def pytest_sessionfinish(_session, _exitstatus):
+    """Remove test-created target directories after all tests complete."""
+    for folder in ("target_pytorch", "target_sklearn"):
+        with contextlib.suppress(Exception):
+            shutil.rmtree(folder)
+
+
 folders = [
     "RES",
     "dt.sav",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ from sacroml.attacks.target import Target
 np.random.seed(1)
 
 
-def pytest_sessionfinish(_session, _exitstatus):
+def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
     """Remove test-created target directories after all tests complete."""
     for folder in ("target_pytorch", "target_sklearn"):
         with contextlib.suppress(Exception):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ from sacroml.attacks.target import Target
 np.random.seed(1)
 
 
-def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
+def pytest_sessionfinish(session, exitstatus):
     """Remove test-created target directories after all tests complete."""
     for folder in ("target_pytorch", "target_sklearn"):
         with contextlib.suppress(Exception):


### PR DESCRIPTION
Closes #404

Ran full test suite with `-W all` on Python 3.12 / numpy 2.4.2 / sklearn 1.8.0.

No numpy deprecation or future warnings found,  those may have been resolved by dependency updates since the issue was opened. All warnings present were RuntimeWarnings.

Before: 89 warnings, 2 test-ordering failures. After: 0 warnings, 136 passed.

The following are changes I made:

- `tests/conftest.py`: force matplotlib Agg backend to prevent Tk failures during full suite runs
- `sacroml/attacks/utils.py`: guard `shapiro()` with `len >= 8` and suppress degenerate-sample warnings
- `sacroml/attacks/report.py`: close figures after saving (×2)
- `sacroml/attacks/attribute_attack.py`: close figures after saving (×2)
- `tests/attacks/test_sklearn.py`: ravel column vector before `LabelEncoder`
- `tests/attacks/test_structural_attack.py`: filter `ConvergenceWarning` on MLP tests (×2)

- added myself to citation as per prior PR merged as advised by rpreen. 

