### PR TITLE
fix: metrics report TPR at percentage FPRs by default

### DIFF
--- a/sacroml/attacks/_scorers.py
+++ b/sacroml/attacks/_scorers.py
@@ -26,8 +26,8 @@ Scorer = Callable[[BaseEstimator, np.ndarray, np.ndarray], float]
 
 _SCORER_KEYS: tuple[str, ...] = (
     "AUC",
-    "TPR@0.1",
-    "TPR@0.001",
+    "TPR@10%",
+    "TPR@0.1%",
     "FDIF01",
     "FDIF02",
     "Advantage",

--- a/sacroml/attacks/_scorers.py
+++ b/sacroml/attacks/_scorers.py
@@ -26,8 +26,8 @@ Scorer = Callable[[BaseEstimator, np.ndarray, np.ndarray], float]
 
 _SCORER_KEYS: tuple[str, ...] = (
     "AUC",
-    "TPR@10%",
     "TPR@0.1%",
+    "TPR@0.001%",
     "FDIF01",
     "FDIF02",
     "Advantage",

--- a/sacroml/attacks/report.py
+++ b/sacroml/attacks/report.py
@@ -20,10 +20,10 @@ DISPLAY_METRICS = [
     "Advantage",
     "FDIF01",
     "PDIF01",
-    "TPR@0.1",
-    "TPR@0.01",
-    "TPR@0.001",
-    "TPR@1e-05",
+    "TPR@10%",
+    "TPR@1%",
+    "TPR@0.1%",
+    "TPR@0.001%",
 ]
 
 MAPPINGS = {"PDIF01": lambda x: np.exp(-x)}

--- a/sacroml/attacks/report.py
+++ b/sacroml/attacks/report.py
@@ -20,10 +20,10 @@ DISPLAY_METRICS = [
     "Advantage",
     "FDIF01",
     "PDIF01",
-    "TPR@10%",
-    "TPR@1%",
     "TPR@0.1%",
+    "TPR@0.01%",
     "TPR@0.001%",
+    "TPR@1e-05%",
 ]
 
 MAPPINGS = {"PDIF01": lambda x: np.exp(-x)}

--- a/sacroml/metrics.py
+++ b/sacroml/metrics.py
@@ -322,8 +322,8 @@ def get_metrics(
     # Add some things useful for debugging / filtering
     metrics["pred_prob_var"] = y_pred_proba.var()
 
-    # TPR at various FPR (percentages, following Carlini et al. 2022)
-    fpr_vals = [50, 20, 10, 1, 0.1, 0.001]
+    # TPR at various FPR
+    fpr_vals = [0.5, 0.2, 0.1, 0.01, 0.001, 0.00001]
     for fpr in fpr_vals:
         tpr = _tpr_at_fpr(y_test, y_pred_proba, fpr=fpr)
         name = f"TPR@{fpr:g}%"

--- a/sacroml/metrics.py
+++ b/sacroml/metrics.py
@@ -39,7 +39,7 @@ def _tpr_at_fpr(
     y_true: Iterable[float],
     y_score: Iterable[float],
     fpr: float = 0.001,
-    fpr_perc: bool = False,
+    fpr_perc: bool = True,
 ) -> float:
     """Compute the TPR at a fixed FPR.
 
@@ -53,9 +53,11 @@ def _tpr_at_fpr(
     y_score : Iterable[float]
         predicted score
     fpr : float
-        false positive rate at which to compute true positive rate
+        false positive rate at which to compute true positive rate.
+        Interpreted as a percentage by default (e.g. 0.1 means 0.1%% FPR),
+        following the Carlini et al. (2022) reporting convention.
     fpr_perc : bool
-        if the fpr is defined as a percentage
+        if the fpr is defined as a percentage (default True)
 
     Returns
     -------
@@ -320,11 +322,11 @@ def get_metrics(
     # Add some things useful for debugging / filtering
     metrics["pred_prob_var"] = y_pred_proba.var()
 
-    # TPR at various FPR
-    fpr_vals = [0.5, 0.2, 0.1, 0.01, 0.001, 0.00001]
+    # TPR at various FPR (percentages, following Carlini et al. 2022)
+    fpr_vals = [50, 20, 10, 1, 0.1, 0.001]
     for fpr in fpr_vals:
         tpr = _tpr_at_fpr(y_test, y_pred_proba, fpr=fpr)
-        name = f"TPR@{fpr}"
+        name = f"TPR@{fpr:g}%"
         metrics[name] = tpr
 
     fpr, tpr, roc_thresh = roc_curve(y_test, y_pred_proba)

--- a/tests/attacks/test_metrics.py
+++ b/tests/attacks/test_metrics.py
@@ -110,20 +110,35 @@ class TestFPRatTPR(unittest.TestCase):
     """Test code that computes TPR at fixed FPR."""
 
     def test_tpr(self):
-        """Test tpr at fpr."""
+        """Test tpr at fpr using explicit raw rates (fpr_perc=False)."""
         y_true = TRUE_CLASS
         y_score = PREDICTED_PROBS[:, 1]
+        tpr = _tpr_at_fpr(y_true, y_score, fpr=0, fpr_perc=False)
+        assert tpr == pytest.approx(2 / 3)
+        tpr = _tpr_at_fpr(y_true, y_score, fpr=0.001, fpr_perc=False)
+        assert tpr == pytest.approx(2 / 3)
+        tpr = _tpr_at_fpr(y_true, y_score, fpr=0.1, fpr_perc=False)
+        assert tpr == pytest.approx(2 / 3)
+        tpr = _tpr_at_fpr(y_true, y_score, fpr=0.4, fpr_perc=False)
+        assert tpr == pytest.approx(1)
+        tpr = _tpr_at_fpr(y_true, y_score, fpr=1.0, fpr_perc=False)
+        assert tpr == pytest.approx(1)
+
+    def test_tpr_perc_default(self):
+        """Test tpr at fpr with default fpr_perc=True (Carlini et al. 2022)."""
+        y_true = TRUE_CLASS
+        y_score = PREDICTED_PROBS[:, 1]
+        # fpr=0 as a percentage is 0% FPR (same as raw 0)
         tpr = _tpr_at_fpr(y_true, y_score, fpr=0)
         assert tpr == pytest.approx(2 / 3)
-        tpr = _tpr_at_fpr(y_true, y_score, fpr=0.001)
+        # fpr=10 means 10% FPR (raw 0.1)
+        tpr = _tpr_at_fpr(y_true, y_score, fpr=10)
         assert tpr == pytest.approx(2 / 3)
-        tpr = _tpr_at_fpr(y_true, y_score, fpr=0.1)
-        assert tpr == pytest.approx(2 / 3)
-        tpr = _tpr_at_fpr(y_true, y_score, fpr=0.4)
+        # fpr=40 means 40% FPR (raw 0.4)
+        tpr = _tpr_at_fpr(y_true, y_score, fpr=40)
         assert tpr == pytest.approx(1)
-        tpr = _tpr_at_fpr(y_true, y_score, fpr=1.0)
-        assert tpr == pytest.approx(1)
-        tpr = _tpr_at_fpr(y_true, y_score, fpr_perc=True, fpr=100.0)
+        # fpr=100 means 100% FPR (raw 1.0)
+        tpr = _tpr_at_fpr(y_true, y_score, fpr=100)
         assert tpr == pytest.approx(1)
 
 

--- a/tests/attacks/test_worst_case_attack.py
+++ b/tests/attacks/test_worst_case_attack.py
@@ -274,7 +274,7 @@ def test_tuning_random_search_with_alt_scorer(common_setup):
 
     tuning = output["metadata"]["tuning"]
     assert tuning["search_type"] == "random"
-    assert tuning["tuning_metric"] == "TPR@10%"
+    assert tuning["tuning_metric"] == "TPR@0.1%"
     assert tuning["n_candidates"] == 3
 
 

--- a/tests/attacks/test_worst_case_attack.py
+++ b/tests/attacks/test_worst_case_attack.py
@@ -268,7 +268,7 @@ def test_tuning_random_search_with_alt_scorer(common_setup):
         attack_model_param_grid=grid,
         search_type="random",
         search_n_iter=3,
-        tuning_metric="TPR@10%",
+        tuning_metric="TPR@0.1%",
     )
     output = attack_obj.attack(target)
 

--- a/tests/attacks/test_worst_case_attack.py
+++ b/tests/attacks/test_worst_case_attack.py
@@ -268,13 +268,13 @@ def test_tuning_random_search_with_alt_scorer(common_setup):
         attack_model_param_grid=grid,
         search_type="random",
         search_n_iter=3,
-        tuning_metric="TPR@0.1",
+        tuning_metric="TPR@10%",
     )
     output = attack_obj.attack(target)
 
     tuning = output["metadata"]["tuning"]
     assert tuning["search_type"] == "random"
-    assert tuning["tuning_metric"] == "TPR@0.1"
+    assert tuning["tuning_metric"] == "TPR@10%"
     assert tuning["n_candidates"] == 3
 
 


### PR DESCRIPTION
This PR updates TPR-at-FPR metrics to use percentage-based FPR values by default, matching the reporting convention used by Carlini et al. (2022).

Metric names now include the percentage sign, for example:

•⁠  ⁠⁠ TPR@10% ⁠
•⁠  ⁠⁠ TPR@0.1% ⁠

The related scorer keys, report metrics, tuning configuration, and tests have been updated accordingly.
