### PR TITLE
docs: move qmia/meta attacks from readme to api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,56 +73,6 @@ attack.attack(target)
 
 For more information, see the [examples](examples/).
 
-## QMIA: Quantile Regression Membership Inference Attack
-
-QMIA implements the attack from [Bertran et al. (NeurIPS 2023)](https://arxiv.org/abs/2307.03694). It trains a histogram-based quantile regressor (`HistGradientBoostingRegressor`) on non-member data to learn per-sample membership thresholds — no shadow models required.
-
-```python
-from sacroml.attacks.qmia_attack import QMIAAttack
-from sacroml.attacks.target import Target
-
-target = Target(model=model, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test)
-attack = QMIAAttack(alpha=0.01, output_dir="output_qmia")
-attack.attack(target)
-```
-
-Key features:
-
-* **Multiclass support** via the full hinge score: `logit(p_y) - max_{y'!=y} logit(p_{y'})`
-* **Q conditioned on (x, y)** — the regressor learns thresholds per sample and label
-* **FPR control** — the quantile level (1 - alpha) calibrates the false-positive rate on non-members
-
-### Benchmarking
-
-Run the full benchmark comparing QMIA against WorstCase and LiRA:
-
-```bash
-python examples/sklearn/benchmark_qmia_full.py
-```
-
-## MetaAttack: Unified Per-Record Vulnerability Aggregation
-
-`MetaAttack` runs multiple privacy attacks (LiRA, QMIA, Structural) on the same target and aggregates their per-record results into a single vulnerability DataFrame.  Three operating modes are supported via the `behaviour` parameter:
-
-* **`'run_all'`** (default) — run every specified attack from scratch.
-* **`'use_existing_only'`** — read per-record scores from pre-existing `report.json` files without re-running anything.  Useful when expensive attacks such as LiRA have already been run.
-* **`'fill_missing'`** — load existing results and run only the attacks not yet present.
-
-```python
-from sacroml.attacks.meta_attack import MetaAttack
-from sacroml.attacks.target import Target
-
-target = Target(model=model, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test)
-meta = MetaAttack(
-    attacks=[("lira", {}), ("qmia", {}), ("structural", {})],
-    behaviour="run_all",  # alternatives: "use_existing_only", "fill_missing"
-    output_dir="output_meta",
-)
-meta.attack(target)
-```
-
-The vulnerability matrix is saved as `vulnerability_matrix.csv` in `output_dir`.
-
 ## Documentation
 
 See [API documentation](https://ai-sdc.github.io/SACRO-ML/).

--- a/docs/source/attacks/index.rst
+++ b/docs/source/attacks/index.rst
@@ -9,6 +9,8 @@ Examples showing how to run the code can be found in the examples folder.
    likelihood
    worst_case
    structural
+   qmia
+   meta
    attribute
    target
    data

--- a/docs/source/attacks/meta.rst
+++ b/docs/source/attacks/meta.rst
@@ -1,0 +1,5 @@
+Meta Attack
+===========
+
+.. automodule:: sacroml.attacks.meta_attack
+    :members:

--- a/docs/source/attacks/qmia.rst
+++ b/docs/source/attacks/qmia.rst
@@ -1,0 +1,5 @@
+QMIA Attack
+===========
+
+.. automodule:: sacroml.attacks.qmia_attack
+    :members:

--- a/sacroml/attacks/meta_attack.py
+++ b/sacroml/attacks/meta_attack.py
@@ -4,30 +4,45 @@ Runs multiple privacy attacks (LiRA, QMIA, Structural) on the same Target,
 extracts per-record vulnerability scores from each, and aggregates them into
 a unified pandas DataFrame with two-level aggregation:
 
-  Level 1 — within-attack: mean, std, and consistency across repeated runs.
-  Level 2 — cross-attack:  arithmetic/geometric mean of MIA scores,
-            binary structural flag, and total vulnerability count.
+* Level 1 — within-attack: Mean, std, and consistency across repeated runs.
+* Level 2 — cross-attack: Arithmetic/geometric mean of MIA scores,
+  binary structural flag, and total vulnerability count.
 
 Supports three operating modes via the *behaviour* parameter:
 
-  ``'run_all'`` (default)
-      Run every specified attack from scratch.
+``'run_all'`` (default)
+    Run every specified attack from scratch.
 
-  ``'use_existing_only'``
-      Read per-record scores from existing ``report.json`` files in
-      *report_dir*; no new attacks are executed.  Use when attacks were
-      already run (possibly at great computational cost) and you only want
-      to collate their results.
+``'use_existing_only'``
+    Read per-record scores from existing ``report.json`` files in
+    *report_dir*; no new attacks are executed. Use when attacks were
+    already run (possibly at great computational cost) and you only want
+    to collate their results.
 
-  ``'fill_missing'``
-      Load any attacks already present in *report_dir* and run only those
-      not yet found.  Saves redundant computation when some attacks have
-      been run but others have not.
+``'fill_missing'``
+    Load any attacks already present in *report_dir* and run only those
+    not yet found. Saves redundant computation when some attacks have
+    been run but others have not.
 
-Reference: AI-SDC/SACRO-ML#428
+The vulnerability matrix is saved as ``vulnerability_matrix.csv`` in ``output_dir``.
+
+Example
+-------
+.. code-block:: python
+
+    from sacroml.attacks.meta_attack import MetaAttack
+    from sacroml.attacks.target import Target
+
+    target = Target(
+        model=model, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+    )
+    meta = MetaAttack(
+        attacks=[("lira", {}), ("qmia", {}), ("structural", {})],
+        behaviour="run_all",  # alternatives: "use_existing_only", "fill_missing"
+        output_dir="output_meta",
+    )
+    meta.attack(target)
 """
-
-from __future__ import annotations
 
 import contextlib
 import copy

--- a/sacroml/attacks/qmia_attack.py
+++ b/sacroml/attacks/qmia_attack.py
@@ -4,14 +4,39 @@ Scalable Membership Inference Attacks via Quantile Regression.
 Bertran et al., NeurIPS 2023. https://arxiv.org/abs/2307.03694
 
 Trains a histogram-based quantile regressor on non-member hinge scores to
-learn per-sample membership thresholds.  A sample is predicted as a member
+learn per-sample membership thresholds. A sample is predicted as a member
 when its observed score exceeds the predicted threshold.
 
 Uses ``HistGradientBoostingRegressor`` rather than ``GradientBoostingRegressor``
 for its histogram-based splitting algorithm, which is faster on large datasets.
-"""
 
-from __future__ import annotations
+Key Features
+------------
+* Multiclass support via full hinge score:
+  ``logit(p_y) - max_{y'!=y} logit(p_{y'})``
+* Q conditioned on (x, y): The regressor learns thresholds per sample and label.
+* FPR control: The quantile level ``(1 - alpha)`` calibrates the
+  false-positive rate on non-members.
+
+Benchmarking
+------------
+Run the full benchmark comparing QMIA against WorstCase and LiRA::
+
+    python examples/sklearn/benchmark_qmia_full.py
+
+Example
+-------
+.. code-block:: python
+
+    from sacroml.attacks.qmia_attack import QMIAAttack
+    from sacroml.attacks.target import Target
+
+    target = Target(
+        model=model, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+    )
+    attack = QMIAAttack(alpha=0.01, output_dir="output_qmia")
+    attack.attack(target)
+"""
 
 import logging
 import uuid


### PR DESCRIPTION
This PR cleans up the README by moving the content for QMIA and Meta attacks to the Sphinx API documentation.